### PR TITLE
ARM: meson: fix pinctrl for eMMC on Libre Computer aml-a311d-cc

### DIFF
--- a/arch/arm/dts/meson-g12b-a311d-libretech-cc-u-boot.dtsi
+++ b/arch/arm/dts/meson-g12b-a311d-libretech-cc-u-boot.dtsi
@@ -6,7 +6,7 @@
 #include "meson-g12-common-u-boot.dtsi"
 
 &sd_emmc_c {
-	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>;
+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
 	bus-width = <4>;
 };
 


### PR DESCRIPTION
Attempt to fix u-boot not reading the eMMC

https://hub.libre.computer/t/emmc-not-recognized-by-u-boot-on-alta/4999/

Make the pinctrl match the other vim3 (also a311d) and the solitude

https://github.com/libre-computer-project/libretech-u-boot/blob/e4c8b32d03d7ecffd586b7d33336603ad639d7c0/arch/arm/dts/meson-khadas-vim3-u-boot.dtsi#L19
https://github.com/libre-computer-project/libretech-u-boot/blob/e4c8b32d03d7ecffd586b7d33336603ad639d7c0/arch/arm/dts/meson-sm1-s905d3-libretech-cc-u-boot.dtsi#L9

